### PR TITLE
Feat/dynamic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     },
     "extends": "google",
     "parserOptions": {
-        "ecmaVersion": 6,
+        "ecmaVersion": 2017,
         "sourceType": "module"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default function htmlTemplate(options = {}) {
       inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
       return null;
     },
-    async generateBundle(outputOptions, bundle, isWrite) {
+    generateBundle: async function generateBundle(outputOptions, bundle, isWrite) {
 
       // get the output dir
       const outputDir = outputOptions.file

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,27 @@ export default function htmlTemplate(options = {}) {
     ? `${targetName}.html`
     : targetName;
 
+  let inputs = [];
+
   return {
     name: 'html-template',
-    generateBundle: function write(outputOptions, bundle, isWrite) {
-      const bundleFile = outputOptions.file;
+    options(opts) {
+      inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
+      return null;
+    },
+    generateBundle(outputOptions, bundle, isWrite) {
+
+      // get the output dir
+      const outputDir = outputOptions.file
+        ? path.dirname(outputOptions.file)
+        : outputOptions.dir;
+
+      const outputName = outputOptions.file
+        ? [path.basename(outputOptions.file)]
+        : inputs.map((i) => path.basename(i));
+
+      console.log(outputDir, outputName)
+
       return new Promise((resolve, reject) =>
         readFile(template, (err, buffer) => {
           if (err) {
@@ -38,14 +55,14 @@ export default function htmlTemplate(options = {}) {
           // Inject the script tag before the body close tag.
           const injected = [
             tmpl.slice(0, bodyCloseTag),
-            `<script src="${path.basename(bundleFile)}"></script>\n`,
+            `<script src="${outputName[0]}"></script>\n`,
             tmpl.slice(bodyCloseTag, tmpl.length),
           ].join('');
 
           // Write the injected template to a file.
           promisify(
             writeFile,
-            path.join(path.dirname(bundleFile), targetFile),
+            path.join(outputDir, targetFile),
             injected
           ).then(() => resolve(), (e) => reject(e));
         })

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,7 @@ export default function htmlTemplate(options = {}) {
       inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
       return null;
     },
-    generateBundle: async function generateBundle(outputOptions, bundle, isWrite) {
-
+    async generateBundle(outputOptions, bundle, isWrite) {
       // get the output dir
       const outputDir = outputOptions.file
         ? path.dirname(outputOptions.file)
@@ -44,11 +43,10 @@ export default function htmlTemplate(options = {}) {
       // read in the template
       const tmpl = await promisify(readFile, template, 'utf8');
       const bodyCloseTag = tmpl.lastIndexOf('</body>');
-      
+
       // write out all of the templates based on the entry files
       return Promise.all(
         entryFiles.map((name) => {
-
           // Inject the script tag before the body close tag.
           const injected = [
             tmpl.slice(0, bodyCloseTag),
@@ -59,14 +57,14 @@ export default function htmlTemplate(options = {}) {
           // convert the entry file extension
           const outputFile = outputOptions.file
           ? targetFile
-          : `${path.basename(name, '.js')}.html`
+          : `${path.basename(name, '.js')}.html`;
 
           // Write the injected template to a file.
           promisify(
             writeFile,
             path.join(outputDir, outputFile),
             injected
-          )
+          );
         })
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ export default function htmlTemplate(options = {}) {
 
   return {
     name: 'html-template',
-    onwrite: function write(writeOptions) {
-      const bundle = writeOptions.file;
+    generateBundle: function write(outputOptions, bundle, isWrite) {
+      const bundleFile = outputOptions.file;
       return new Promise((resolve, reject) =>
         readFile(template, (err, buffer) => {
           if (err) {
@@ -38,14 +38,14 @@ export default function htmlTemplate(options = {}) {
           // Inject the script tag before the body close tag.
           const injected = [
             tmpl.slice(0, bodyCloseTag),
-            `<script src="${path.basename(bundle)}"></script>\n`,
+            `<script src="${path.basename(bundleFile)}"></script>\n`,
             tmpl.slice(bodyCloseTag, tmpl.length),
           ].join('');
 
           // Write the injected template to a file.
           promisify(
             writeFile,
-            path.join(path.dirname(bundle), targetFile),
+            path.join(path.dirname(bundleFile), targetFile),
             injected
           ).then(() => resolve(), (e) => reject(e));
         })


### PR DESCRIPTION
Hey @bengsfort,
I've been working on getting rollup-plugin-generate-html-template to handle [code splitting](https://github.com/rollup/rollup-starter-code-splitting), this is my first attempt. I though I'd issue a pull request at this stage before I do any more to see if your interested.

Additional things that need to be done:

- The code splitting starter creates a seperate directory for the _module_ and _nomodule_ files. The html file is common to both so there will need to be some additional directory management done, saving the template to the right location.
- It's currently assuming `.js` entry files, but will need to accomodate other files extensions, e.g. `.jsx`
- handle the templated file extension better

Let me know what you think.