### PR TITLE
fix(build): add npm build on prepublishOnly to ensure full publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:cjs": "rollup -c -o ./dist/rollup-plugin-generate-html-template.js -f cjs",
     "build:module": "rollup -c -o ./dist/rollup-plugin-generate-html-template.module.js -f es",
     "prebuild": "rimraf dist/*",
+    "prepublishOnly": "npm run build",
     "lint": "eslint ./src"
   },
   "repository": {


### PR DESCRIPTION
Added prepublishOnly script to make sure that a fresh build of dist is included with npm publish.