### PR TITLE
Add more explicit error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,11 @@ export default function htmlTemplate(options = {}) {
     generateBundle: function generateBundle(outputOptions) {
       // check output is configured correctly
       if (!outputOptions.file && outputOptions.dir) {
-        throw new Error('Only works with `ouput.file` option not `output.dir` option');
+        throw new Error(
+          'Only works with `ouput.file` option not `output.dir` option'
+        );
       }
-      
+
       const bundle = outputOptions.file;
       return new Promise((resolve, reject) =>
         readFile(template, (err, buffer) => {

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export default function htmlTemplate(options = {}) {
       // check output is configured correctly
       if (!outputOptions.file && outputOptions.dir) {
         throw new Error(
-          'Only works with `ouput.file` option not `output.dir` option'
+            'Only works with `ouput.file` option not `output.dir` option'
         );
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,11 @@ export default function htmlTemplate(options = {}) {
   return {
     name: 'html-template',
     generateBundle: function generateBundle(outputOptions) {
+      // check output is configured correctly
+      if (!outputOptions.file && outputOptions.dir) {
+        throw new Error('Only works with `ouput.file` option not `output.dir` option');
+      }
+      
       const bundle = outputOptions.file;
       return new Promise((resolve, reject) =>
         readFile(template, (err, buffer) => {


### PR DESCRIPTION
When using rollup with `output.dir` it gives a path error that might throw off some people if they don't feel like looking into the cause. This makes it more clear that you need to set `output.file` instead of `output.dir` for this to work..