### PR TITLE
Fixing issue where replaceVars would only replace first instance

### DIFF
--- a/__tests__/fixtures/template_replace.html
+++ b/__tests__/fixtures/template_replace.html
@@ -2,5 +2,7 @@
   <body>
     <h1>Hello World.</h1>
     <h2>__HOME_URL__</h2>
+    <a href="__HOME_URL__">__HOME_URL__</a>
+    <p>__COMPLEX__!@$#{}/()_REPLACEMENT__</p>
   </body>
 </html>

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -11,13 +11,19 @@ function getHtmlString(
   bundle = "bundle.js",
   prefix = "",
   attrs = [],
-  replaceValue
+  replaceValues = []
 ) {
   return `
   <html>
     <body>
       <h1>Hello World.</h1>
-        ${Boolean(replaceValue) ? `<h2>${replaceValue}</h2>` : ""}
+        ${Boolean(replaceValues[0]) ? `<h2>${replaceValues[0]}</h2>` : ""}
+        ${
+          Boolean(replaceValues[0])
+            ? `<a href="${replaceValues[0]}">${replaceValues[0]}</a>`
+            : ""
+        }
+        ${Boolean(replaceValues[1]) ? `<p>${replaceValues[1]}</p>` : ""}
       ${
         typeof bundle !== "string" && bundle.length
           ? bundle
@@ -106,7 +112,7 @@ it("should correctly add the attributes to the injected script tag", async () =>
   );
 });
 
-it("correctly replaces HTML variables", async () => {
+it("correctly replaces all HTML variables", async () => {
   const BUNDLE_PATH = path.join(TEST_DIR, "bundle.js");
   // Defaults to not renaming the template.
   const TEMPLATE_PATH = path.join(TEST_DIR, "template_replace.html");
@@ -117,6 +123,7 @@ it("correctly replaces HTML variables", async () => {
         template: `${__dirname}/fixtures/template_replace.html`,
         replaceVars: {
           __HOME_URL__: "cool.com",
+          "__COMPLEX__!@$#{}/()_REPLACEMENT__": "complex replacement",
         },
       }),
     ],
@@ -136,7 +143,7 @@ it("correctly replaces HTML variables", async () => {
   // Ensure output has bundle injected
   const generatedTemplate = await fs.readFile(TEMPLATE_PATH, "utf8");
   expect(generatedTemplate.replace(/[\s]/gi, "")).toEqual(
-    getHtmlString("bundle.js", "", [], "cool.com")
+    getHtmlString("bundle.js", "", [], ["cool.com", "complex replacement"])
   );
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import fs from "fs-extra";
 import path from "path";
+import escapeStringRegexp from "escape-string-regexp";
 
 const INVALID_ARGS_ERROR =
   "[rollup-plugin-generate-html-template] You did not provide a template or target!";
@@ -38,8 +39,10 @@ export default function htmlTemplate(options = {}) {
           let tmpl = buffer.toString("utf8");
           if (replaceVars) {
             const replacePairs = Object.entries(replaceVars);
-            replacePairs.forEach(pair => {
-              tmpl = tmpl.replace(pair[0], pair[1]);
+            replacePairs.forEach(([pattern, replacement]) => {
+              const escapedPattern = escapeStringRegexp(pattern);
+              const regex = new RegExp(`${escapedPattern}`, "g");
+              tmpl = tmpl.replace(regex, replacement);
             });
           }
           const bodyCloseTag = tmpl.lastIndexOf("</body>");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,6 +1823,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.9.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"


### PR DESCRIPTION
As it says on the tin - the previous code was just doing a String.replace using a substr, so would only replace the first instance of the variable. The test also only covered replacing one var, which presumably is why this was not caught.

This contradicted what is mentioned in the readme for the `replaceVars` option:

>...will replace **all** instances of __CDN_URL__ with http://mycdn.com

I've updated the replacement code to use a regular expression with the 'g' flag, to ensure all instances are replaced. Left it case sensitive as default, as I feel this should be a user decision.

As a result of this, I've added the `escape-string-regexp` dependency, as any replacement strings passed should be escaped before being used to create a RegExp, as a user could potentially pass a string with weird chars. Didn't think there was much point trying to write this myself...

Updated test and fixture to ensure multiple and 'complex' replacements are tested for.

Cheers for the rad plugin - find it very useful when working on small rollup powered templates