### PR TITLE
Target parameter could be used as a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On final bundle generation the provided template file will have a `script` tag i
 ### Options
 
 - `template`: **(required)** The path to the source template.
-- `target`: The file name to use for the html file generated with the bundle.
+- `target`: The directory and file name to use for the html file generated with the bundle.
 - `attrs`: The attributes provided to the generated bundle script tag. Passed as an array of strings
   Example: `attrs: ['async', 'defer]` will generate `<script async defer src="bundle.js"></script>`
 - `replaceVars`: An object containing variables that will be replaced in the generated html.

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -205,6 +205,36 @@ it("should rename templates if provided a target option.", async () => {
   await expect(fs.pathExists(TEMPLATE_PATH)).resolves.toEqual(true);
 });
 
+it("should save template into directory if provided target option is a directory.", async () => {
+  const BUNDLE_PATH = path.join(TEST_DIR, "public/build/bundle.js");
+  const TEMPLATE_PATH = path.join(TEST_DIR, "public/index.html");
+
+  const input = {
+    input: `${__dirname}/fixtures/index.js`,
+    plugins: [
+      htmlTemplate({
+        template: `${__dirname}/fixtures/template.html`,
+        prefix: "build/",
+        target: TEMPLATE_PATH,
+      }),
+    ],
+  };
+  const output = {
+    file: BUNDLE_PATH,
+    format: "iife",
+    name: "test",
+  };
+  const bundle = await rollup(input);
+  await bundle.write(output);
+
+  // Ensure files exist
+  expect(fs.pathExists(BUNDLE_PATH)).resolves.toEqual(true);
+  expect(fs.pathExists(TEMPLATE_PATH)).resolves.toEqual(true);
+  const resultHtml = await fs.readFile(TEMPLATE_PATH, "utf8");
+  const [, srcString] = resultHtml.match(/<script.*src="(.*)">/);
+  expect(srcString).toEqual("build/bundle.js");
+});
+
 it("should work with chunking", async () => {
   const BUNDLE_CHUNK_1 = path.join(TEST_DIR, "entry-index.js");
   const BUNDLE_CHUNK_2 = path.join(TEST_DIR, "entry-nested/bar.js");

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -214,7 +214,6 @@ it("should save template into directory if provided target option is a directory
     plugins: [
       htmlTemplate({
         template: `${__dirname}/fixtures/template.html`,
-        prefix: "build/",
         target: TEMPLATE_PATH,
       }),
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ export default function htmlTemplate(options = {}) {
     name: "html-template",
 
     async generateBundle(outputOptions, bundleInfo) {
-      const targetDir = outputOptions.dir || path.dirname(outputOptions.file);
       const bundles = getEntryPoints(bundleInfo);
       return new Promise(async (resolve, reject) => {
         try {
@@ -57,6 +56,13 @@ export default function htmlTemplate(options = {}) {
             ),
             tmpl.slice(bodyCloseTag, tmpl.length),
           ].join("");
+
+          const defaultDir =
+            outputOptions.dir || path.dirname(outputOptions.file);
+          const targetDir =
+            target && path.dirname(target) !== "."
+              ? path.dirname(target)
+              : defaultDir;
 
           // write the injected template to a file
           const finalTarget = path.join(targetDir, targetFile);

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,18 @@ export default function htmlTemplate(options = {}) {
         try {
           if (!target && !template) throw new Error(INVALID_ARGS_ERROR);
 
+          const outputDir =
+            outputOptions.dir || path.dirname(outputOptions.file);
+
+          let targetDir = outputDir;
+          let bundleDirString = "";
+
+          if (target && path.dirname(target) !== ".") {
+            targetDir = path.dirname(target);
+            const bundleDir = path.relative(targetDir, outputDir);
+            bundleDirString = bundleDir && `${bundleDir}/`;
+          }
+
           // Get the target file name.
           const targetName = path.basename(target || template);
 
@@ -51,18 +63,12 @@ export default function htmlTemplate(options = {}) {
             tmpl.slice(0, bodyCloseTag),
             ...bundles.map(
               b =>
-                `<script ${scriptTagAttributes.join(" ")} src="${prefix ||
-                  ""}${b}"></script>\n`
+                `<script ${scriptTagAttributes.join(
+                  " "
+                )} src="${bundleDirString}${prefix || ""}${b}"></script>\n`
             ),
             tmpl.slice(bodyCloseTag, tmpl.length),
           ].join("");
-
-          const defaultDir =
-            outputOptions.dir || path.dirname(outputOptions.file);
-          const targetDir =
-            target && path.dirname(target) !== "."
-              ? path.dirname(target)
-              : defaultDir;
 
           // write the injected template to a file
           const finalTarget = path.join(targetDir, targetFile);


### PR DESCRIPTION
Should resolve #21 

**Problem**:
`target` parameter is used only for target name, but there are cases, when wanted output structure got different output dirs for the bundles and for the html.

**Solution**:
checking if the string in `target` as a directory, and if it is, creating different target dir and calculating relative dir for the bundles