### PR TITLE
Add scriptIncludeFilter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ On final bundle generation the provided template file will have a `script` tag i
 
 - `template`: **(required)** The path to the source template.
 - `target`: The directory and file name to use for the html file generated with the bundle.
-- `attrs`: The attributes provided to the generated bundle script tag. Passed as an array of strings
+- `attrs`: The attributes provided to the generated bundle script tag. Passed as an array of strings \
   Example: `attrs: ['async', 'defer]` will generate `<script async defer src="bundle.js"></script>`
-- `replaceVars`: An object containing variables that will be replaced in the generated html.
+- `replaceVars`: An object containing variables that will be replaced in the generated html. \
     Example: `replaceVars: { '__CDN_URL__': process.env.NODE_ENV === 'production' ? 'https://mycdn.com' : '' }` will replace all instances of `__CDN_URL__` with `http://mycdn.com` if the environment is production
+- `scriptIncludeFilter`: A filter function `(id, `[`AssetInfo` or `ChunkInfo`](https://rollupjs.org/guide/en/#generatebundle)`) => boolean` controlling which .js chunks are injected as script tags. \
+    Example: ``(id, fileInfo) => fileInfo.isEntry`` will only inject static entry points (restores behavior of <= v1.6.1), ``(id, fileInfo) => fileInfo.isEntry && id.match(/^index.*\.js$/i)`` will only inject those matching index*.js
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const INVALID_ARGS_ERROR =
  */
 export default function htmlTemplate(options = {}) {
   const { template, target, prefix, attrs, replaceVars } = options;
+  const scriptIncludeFilter = options.scriptIncludeFilter || (() => true);
   const scriptTagAttributes = attrs && attrs.length > 0 ? attrs : [];
   return {
     name: "html-template",
@@ -81,7 +82,11 @@ export default function htmlTemplate(options = {}) {
           injected = [
             injected.slice(0, bodyCloseTag),
             ...bundleKeys
-              .filter(f => path.extname(f) === ".js")
+              .filter(
+                f =>
+                  path.extname(f) === ".js" &&
+                  scriptIncludeFilter(f, bundleInfo[f])
+              )
               .map(
                 b =>
                   `<script ${scriptTagAttributes.join(


### PR DESCRIPTION
Added a new option `scriptIncludeFilter` to optionally control which .js chunks are injected as script tags.
By default nothing is filtered/changed
 
For instance:
* `scriptIncludeFilter: (id, fileInfo) => fileInfo.isEntry` \
Resolves #34 and restores the original v1.6.1 behavior
(maybe this should become the default?)

* `scriptIncludeFilter: (id, fileInfo) => fileInfo.isEntry && id.match(/^index.*\.js$/i)`
Multiple entry chunks, but only `index*.js` should be injected. My use case is web workers with [rollup-plugin-off-main-thread](https://github.com/surma/rollup-plugin-off-main-thread).
 